### PR TITLE
Update README.md install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
-bam
-====
+![bíogo](https://raw.githubusercontent.com/biogo/biogo/master/biogo.png)
 
-Pure Go SAM and BAM handling
+#HTS
 
-go get code.google.com/p/biogo.hts
+##Installation
+
+        $ go get github.com/biogo/hts/...
+
+##Overview
+
+SAM and BAM handling for the Go language.
+
+## Citing ##
+
+If you use bíogo, please cite Kortschak and Adelson "bíogo: a simple high-performance bioinformatics toolkit for the Go language", doi:[10.1101/005033](http://biorxiv.org/content/early/2014/05/12/005033).
+
+##Library Structure and Coding Style
+
+The coding style should be aligned with normal Go idioms as represented in the
+Go core libraries.
+
+##Copyright and License
+
+Copyright ©2011-2013 The bíogo Authors except where otherwise noted. All rights
+reserved. Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+
+The bíogo logo is derived from Bitstream Charter, Copyright ©1989-1992
+Bitstream Inc., Cambridge, MA.
+
+BITSTREAM CHARTER is a registered trademark of Bitstream Inc.


### PR DESCRIPTION
Additional sections copied from the biogo readme.

Omitted the following line from the Library Structure and Coding Style section:
The bíogo library structure is influenced both by the Go core library.