### PR TITLE
bgzf,bgzf/index: prevent ChunkReader overreading when an end is at block offset 0

### DIFF
--- a/bgzf/index/index.go
+++ b/bgzf/index/index.go
@@ -70,12 +70,9 @@ func (r *ChunkReader) Read(p []byte) (int, error) {
 	// blocked mode and so will stop there anyway.
 	want := int(r.chunks[0].End.Block)
 	if r.chunks[0].End.Block == 0 && r.chunks[0].End.File > last.End.File {
-		// Special case for when the current end block offset is zero.
-		// We pick an arbitrary length (the maximum progression).
-		// Because we must move past the current bgzf block to get
-		// to the current chunk end this is safe since the bgzf
-		// Reader is in blocked mode.
-		want = len(p)
+		// Special case for when the current end block offset
+		// is zero.
+		want = r.r.BlockLen()
 	}
 	var cursor int
 	if last.End.File == r.chunks[0].End.File {

--- a/bgzf/index/index_test.go
+++ b/bgzf/index/index_test.go
@@ -265,13 +265,9 @@ func (s *S) TestIssue10(c *check.C) {
 
 					var got bytes.Buffer
 					io.Copy(&got, cr)
-					gotString := got.String()
-					c.Check(strings.Contains(gotString, want), check.Equals, true,
+					c.Check(got.String(), check.Equals, want,
 						check.Commentf("clean=%t merge=%t trunc=%t chunks=%+v", clean, strategy != nil, truncFinal, chunks),
 					)
-					if gotString != want {
-						c.Logf("read over-run clean=%t merge=%t trunc=%t:\n\tgot: %q\n\twant:%q", clean, strategy != nil, truncFinal, gotString, want)
-					}
 				}
 			}
 		}


### PR DESCRIPTION
@brentp Please take a look.