### PR TITLE
Add Cigar.RefLen()

### DIFF
--- a/sam/cigar.go
+++ b/sam/cigar.go
@@ -52,6 +52,19 @@ func (c Cigar) String() string {
 	return b.String()
 }
 
+// Lengths returns the number of reference and read bases described by the Cigar.
+func (c Cigar) Lengths() (ref, read int) {
+	var con Consume
+	for _, co := range c {
+		con = co.Type().Consumes()
+		if co.Type() != CigarBack {
+			ref += co.Len() * con.Reference
+		}
+		read += co.Len() * con.Query
+	}
+	return ref, read
+}
+
 // CigarOp is a single CIGAR operation including the operation type and the
 // length of the operation.
 type CigarOp uint32

--- a/sam/sam_test.go
+++ b/sam/sam_test.go
@@ -696,3 +696,26 @@ func (s *S) TestIssue26(c *check.C) {
 	c.Check(prog.Get(idTag), check.Equals, "program")
 	c.Check(prog.Get(fuTag), check.Equals, "bar")
 }
+
+var cigTests = []struct {
+	cig  []byte
+	ref  int
+	read int
+}{
+	{[]byte("151M"), 151, 151},
+	{[]byte("10S10M"), 10, 20},
+	{[]byte("11H11M"), 11, 11},
+	{[]byte("11H1D11M"), 12, 11},
+	{[]byte("5M21N5M"), 31, 10},
+	{[]byte("21N"), 21, 0},
+}
+
+func (s *S) TestLengths(c *check.C) {
+	for _, ct := range cigTests {
+		cig, err := ParseCigar(ct.cig)
+		c.Check(err, check.IsNil)
+		ref, read := cig.Lengths()
+		c.Check(ref, check.Equals, ct.ref)
+		c.Check(read, check.Equals, ct.read)
+	}
+}


### PR DESCRIPTION
When parsing SA tags or MD, we may also need to know the length often
the chimeric alignment or determine the length of the Cigar. With this
change, it is possible to do so without replicating code in Record.End()

I'm not sure RefLen() is the best name...