### PR TITLE
replace bytes.Compare with faster comparison for tag.

### DIFF
--- a/sam/auxtags.go
+++ b/sam/auxtags.go
@@ -461,6 +461,10 @@ func (a Aux) Value() interface{} {
 	}
 }
 
+func (a Aux) matches(tag []byte) bool {
+	return a[1] == tag[1] && a[0] == tag[0]
+}
+
 // AuxFields is a set of auxiliary fields.
 type AuxFields []Aux
 

--- a/sam/record.go
+++ b/sam/record.go
@@ -105,12 +105,15 @@ func IsValidRecord(r *Record) bool {
 // Tag returns an Aux tag whose tag ID matches the first two bytes of tag and true.
 // If no tag matches, nil and false are returned.
 func (r *Record) Tag(tag []byte) (v Aux, ok bool) {
-	for i := range r.AuxFields {
-		if bytes.Compare(r.AuxFields[i][:2], tag) == 0 {
-			return r.AuxFields[i], true
+	if len(tag) < 2 {
+		panic("sam: tag too short")
+	}
+	for _, aux := range r.AuxFields {
+		if aux.matches(tag) {
+			return aux, true
 		}
 	}
-	return
+	return nil, false
 }
 
 // RefID returns the reference ID for the Record.


### PR DESCRIPTION
Record.Tag() is showing up in my profiling. This drastically reduces the time spent there:

The time for the code below gives:
```
benchmark            old ns/op     new ns/op     delta
BenchmarkStats-4     28.0          7.36          -73.71%

benchmark            old allocs     new allocs     delta
BenchmarkStats-4     0              0              +0.00%

benchmark            old bytes     new bytes     delta
BenchmarkStats-4     0             0             +0.00%
```


```Go
package main

import (
    "log"
    "testing"

    "github.com/biogo/hts/sam"
)

func main() {
}

func mustAux(a sam.Aux, err error) sam.Aux {
    if err != nil {
        panic(err)
    }
    return a
}

func BenchmarkStats(b *testing.B) {
    r := &sam.Record{
        AuxFields: []sam.Aux{
            mustAux(sam.NewAux(sam.NewTag("NM"), "AAAAAAAAAAAAAAAA")),
            mustAux(sam.NewAux(sam.NewTag("XA"), "AAAAAAAAAAAAAAAA")),
            mustAux(sam.NewAux(sam.NewTag("MC"), "AAAAAAAAAAAAAAAA")),
            mustAux(sam.NewAux(sam.NewTag("SA"), "ref,29,-,6H5M,17,0;")),
        },
    }
    key := []byte("SA")
    b.ReportAllocs()

    for i := 0; i < b.N; i++ {
        t, ok := r.Tag(key)
        if !ok {
            log.Fatal("didn't find tag")
        }
        _ = t

    }
}
```