### PR TITLE
Aux allocate

### DIFF
--- a/bam/reader.go
+++ b/bam/reader.go
@@ -304,7 +304,11 @@ var jumps = [256]int{
 
 // parseAux examines the data of a SAM record's OPT fields,
 // returning a slice of sam.Aux that are backed by the original data.
-func parseAux(aux []byte) (aa []sam.Aux) {
+func parseAux(aux []byte) []sam.Aux {
+	if len(aux) == 0 {
+		return nil
+	}
+	aa := make([]sam.Aux, 0, 4)
 	for i := 0; i+2 < len(aux); {
 		t := aux[i+2]
 		switch j := jumps[t]; {
@@ -340,7 +344,7 @@ func parseAux(aux []byte) (aa []sam.Aux) {
 			panic(fmt.Sprintf("bam: unrecognised optional field type: %q", t))
 		}
 	}
-	return
+	return aa
 }
 
 // buffer is light-weight read buffer.


### PR DESCRIPTION
this PR pre-allocates a slice of cap 3 when there are any Aux fields. 
Comparing to the commit in #42:
```
name    old time/op    new time/op    delta
Read-4    5.81ms ± 1%    5.48ms ± 1%   -5.59%  (p=0.008 n=5+5)

name    old alloc/op   new alloc/op   delta
Read-4    4.86MB ± 0%    4.25MB ± 0%  -12.60%  (p=0.008 n=5+5)

name    old allocs/op  new allocs/op  delta
Read-4     29.9k ± 0%     24.6k ± 0%  -17.68%  (p=0.008 n=5+5)
```

and comparing on the same bam with all tags removed:
```
name    old time/op    new time/op    delta
Read-4    3.29ms ± 1%    3.32ms ± 2%   ~     (p=0.548 n=5+5)

name    old alloc/op   new alloc/op   delta
Read-4    1.96MB ± 0%    1.96MB ± 0%   ~     (p=0.421 n=5+5)

name    old allocs/op  new allocs/op  delta
Read-4     16.5k ± 0%     16.5k ± 0%   ~     (p=0.349 n=5+5)
```
