### PR TITLE
bam: handle empty chunks during iterator creation

### DIFF
--- a/bam/reader.go
+++ b/bam/reader.go
@@ -241,13 +241,14 @@ type Iterator struct {
 //  return i.Close()
 //
 func NewIterator(r *Reader, chunks []bgzf.Chunk) (*Iterator, error) {
-	if len(chunks) != 0 {
-		err := r.SetChunk(&chunks[0])
-		if err != nil {
-			return nil, err
-		}
-		chunks = chunks[1:]
+	if len(chunks) == 0 {
+		return &Iterator{r: r, err: io.EOF}, nil
 	}
+	err := r.SetChunk(&chunks[0])
+	if err != nil {
+		return nil, err
+	}
+	chunks = chunks[1:]
 	return &Iterator{r: r, chunks: chunks}, nil
 }
 


### PR DESCRIPTION
Previously an empty chunks parameter would result in a complete iteration over the bam. Now we prime the iterator as having completed when there is no chunk to iterate over.

@brentp Please take a look.