### PR TITLE
bgzf: fix magic block detection

### DIFF
--- a/bgzf/bgzf_test.go
+++ b/bgzf/bgzf_test.go
@@ -186,7 +186,7 @@ func TestRoundTrip(t *testing.T) {
 		t.Errorf("comment is %q, want %q", r.Comment, "comment")
 	}
 	if bl := ExpectedMemberSize(r.Header); bl != len(MagicBlock) {
-		t.Errorf("expectedMemberSize is %d, want %d", bl, wbl)
+		t.Errorf("expectedMemberSize is %d, want %d", bl, len(MagicBlock))
 	}
 	if string(r.Extra) != "BC\x02\x00\x1b\x00" {
 		t.Errorf("extra is %q, want %q", r.Extra, "BC\x02\x00\x1b\x00")

--- a/bgzf/cache.go
+++ b/bgzf/cache.go
@@ -170,7 +170,8 @@ func (b *block) NextBase() int64 {
 func (b *block) setHeader(h gzip.Header) {
 	b.h = h
 	b.magic = h.OS == 0xff &&
-		h.ModTime.Equal(unixEpoch) &&
+		// Test for zero time and old compress/gzip behaviour.
+		(h.ModTime.IsZero() || h.ModTime.Equal(unixEpoch)) &&
 		h.Name == "" &&
 		h.Comment == "" &&
 		bytes.Equal(h.Extra, []byte("BC\x02\x00\x1b\x00"))


### PR DESCRIPTION
@brentp Please take a look.

This handles both 1.8 compress/gzip behaviour and pre-1.8 behaviour.

Also fix incorrect test error report value.

Fixes #50.