### PR TITLE
paper/examples/flagstat: use heavier benchmark and match logic

### DIFF
--- a/paper/examples/flagstat/README.md
+++ b/paper/examples/flagstat/README.md
@@ -1,51 +1,76 @@
 flagstat
 ========
 
-This example replicates most of the output of [samtools](https://samtools.github.io) flagstat command.
-With a single core, the program is 20-30% slower, but the Go program becomes faster when using 2 cores.
+This example replicates the output of [samtools](https://samtools.github.io) flagstat command.
+With a single core, the program is significantly slower, but the Go program comparable performance with 4 cores and surpassing the C implementation with 8.
 
-On an example bam the output of samtools is:
+On an example BAM file the output of samtools (1.3.2-199-gec1d68e/htslib 1.3.2-199-gec1d68e) is:
 ```
-$ time samtools flagstat $bam
-4284701 + 0 in total (QC-passed reads + QC-failed reads)
+$ time samtools flagstat 9827_2#49.bam
+56463236 + 0 in total (QC-passed reads + QC-failed reads)
 0 + 0 secondary
-9319 + 0 supplementary
-206663 + 0 duplicates
-4273403 + 0 mapped (99.74% : N/A)
-4275382 + 0 paired in sequencing
-2137869 + 0 read1
-2137513 + 0 read2
-4230981 + 0 properly paired (98.96% : N/A)
-4252786 + 0 with itself and mate mapped
-11298 + 0 singletons (0.26% : N/A)
-16955 + 0 with mate mapped to a different chr
-10934 + 0 with mate mapped to a different chr (mapQ>=5)
+0 + 0 supplementary
+269248 + 0 duplicates
+55357963 + 0 mapped (98.04% : N/A)
+56463236 + 0 paired in sequencing
+28231618 + 0 read1
+28231618 + 0 read2
+54363468 + 0 properly paired (96.28% : N/A)
+55062652 + 0 with itself and mate mapped
+295311 + 0 singletons (0.52% : N/A)
+360264 + 0 with mate mapped to a different chr
+300699 + 0 with mate mapped to a different chr (mapQ>=5)
 
-real    0m10.301s
-user    0m10.232s
-sys 0m0.052s
+real	1m31.517s
+user	1m30.268s
+sys	0m1.180s
 ```
 
-and of this command on the same bam is:
+and of this command (Go 1.8) on the same file is:
 ```
-$ go build -o flagstat flagstat.go
+$ go build github.com/biogo/hts/paper/examples/flagstat
 $ export GOMAXPROCS=1
-$ time ./flagstat $bam
-4284701 + 0 in total (QC-passed reads + QC-failed reads)
+$ time ./flagstat 9827_2#49.bam
+56463236 + 0 in total (QC-passed reads + QC-failed reads)
 0 + 0 in total secondary
-9319 + 0 in total supplementary
-206489 + 0 duplicates
-4273403 + 0 mapped
-2137869 + 0 read1
-2137513 + 0 read2
-4230981 + 0 properly paired
-11298 + 0 singletons
-16955 + 0 with mate mapped to a different chr
-10934 + 0 with mate mapped to a different chr (mapQ >= 5)
+0 + 0 in total supplementary
+269248 + 0 duplicates
+55357963 + 0 mapped (98.04% : N/A)
+56463236 + 0 paired in sequencing
+28231618 + 0 read1
+28231618 + 0 read2
+54363468 + 0 properly paired (96.28% : N/A)
+55062652 + 0 with itself and mate mapped
+295311 + 0 singletons (0.52% : N/A)
+360264 + 0 with mate mapped to a different chr
+300699 + 0 with mate mapped to a different chr (mapQ >= 5)
 
-real	0m12.350s
-user	0m12.164s
-sys	0m0.116s
+real	5m2.323s
+user	5m0.312s
+sys	0m2.148s
 ```
 
-with 2 and 3 processors, this gives identical output in about 7.2 and 6.6 seconds of real time respectively.
+The following give the same flagstat output, but with reduced time.
+
+GOMAXPROCS=2
+```
+real	2m41.310s
+user	5m18.948s
+sys	0m2.600s
+```
+
+GOMAXPROCS=4
+```
+real	1m40.957s
+user	6m21.232s
+sys	0m3.688s
+```
+
+GOMAXPROCS=8
+```
+real	1m28.465s
+user	9m7.480s
+sys	0m8.056s
+```
+
+The file used in the benchmark was 9827_2#49.bam, available from ftp://ftp.sra.ebi.ac.uk/vol1/ERA242/ERA242167/bam/9827_2%2349.bam

--- a/paper/examples/flagstat/flagstat.go
+++ b/paper/examples/flagstat/flagstat.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// This package tabulates statistics on a bam file from the sam flag.
+// This program tabulates statistics on a bam file from the sam flag.
 // It replicates functionality in samtools flagstat.
 package main
 
@@ -13,6 +13,7 @@ import (
 	"os"
 
 	"github.com/biogo/hts/bam"
+	"github.com/biogo/hts/bgzf"
 	"github.com/biogo/hts/sam"
 )
 
@@ -30,17 +31,26 @@ func main() {
 		log.Fatal(err)
 	}
 	defer f.Close()
+	ok, err := bgzf.HasEOF(f)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if !ok {
+		log.Println("EOF block missing")
+	}
+
 	b, err := bam.NewReader(f, 0)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer b.Close()
-	b.Omit(2)
+	b.Omit(bam.AllVariableLengthData)
 
 	// counts is indexed by [pass/fail][sam.Flag] where we have 12 possible sam Flags.
 	var counts [2][12]uint64
 	// track mates on different chromosomes.
-	var mates [2]struct{ low, high uint64 }
+	var mates [2]struct{ allMapQ, highMapQ uint64 }
+	var good, singletons, paired [2]uint64
 	var qc int
 	for {
 		read, err := b.Read()
@@ -56,55 +66,69 @@ func main() {
 			qc = fail
 		}
 
-		counts[qc][0]++
-		if read.Flags&sam.Supplementary != 0 {
-			counts[qc][Supplementary]++
-		} else if read.Flags&sam.Secondary != 0 {
-			counts[qc][Secondary]++
-		} else {
-			for i := uint(1); i < 12; i++ {
-				if read.Flags&(1<<i) != 0 {
-					counts[qc][i]++
-				}
+		for i := Paired; i <= Supplementary; i++ {
+			if read.Flags&(1<<i) != 0 {
+				counts[qc][i]++
 			}
 		}
 
-		const mask = sam.Secondary | sam.ProperPair | sam.Supplementary | sam.Unmapped
-		if read.Flags&mask == 0 {
+		const goodMask = sam.ProperPair | sam.Unmapped
+		if read.Flags&goodMask == sam.ProperPair {
+			good[qc]++
+		}
+
+		const mapMask = sam.MateUnmapped | sam.Unmapped
+		switch read.Flags & mapMask {
+		case sam.MateUnmapped:
+			singletons[qc]++
+		case 0:
+			paired[qc]++
 			if read.MateRef != read.Ref && read.MateRef != nil && read.Ref != nil {
 				if read.MapQ > 4 {
-					mates[qc].high++
+					mates[qc].highMapQ++
 				}
-				mates[qc].low++
+				mates[qc].allMapQ++
 			}
 		}
 	}
+
 	// extract counts to match output from samtools flagstat.
 	fmt.Printf("%d + %d in total (QC-passed reads + QC-failed reads)\n", counts[pass][Paired], counts[fail][Paired])
 	fmt.Printf("%d + %d in total secondary\n", counts[pass][Secondary], counts[fail][Secondary])
 	fmt.Printf("%d + %d in total supplementary\n", counts[pass][Supplementary], counts[fail][Supplementary])
 	fmt.Printf("%d + %d duplicates\n", counts[pass][Duplicate], counts[fail][Duplicate])
-	fmt.Printf("%d + %d mapped\n", counts[pass][Paired]-counts[pass][Unmapped], counts[fail][Paired]-counts[fail][Unmapped])
+	mappedPass := counts[pass][Paired] - counts[pass][Unmapped]
+	mappedFail := counts[fail][Paired] - counts[fail][Unmapped]
+	fmt.Printf("%d + %d mapped (%s : %s)\n", mappedPass, mappedFail, percent(mappedPass, counts[pass][Paired]), percent(mappedFail, counts[fail][Paired]))
+	fmt.Printf("%d + %d paired in sequencing\n", counts[pass][Paired], counts[fail][Paired])
 	fmt.Printf("%d + %d read1\n", counts[pass][Read1], counts[fail][Read1])
 	fmt.Printf("%d + %d read2\n", counts[pass][Read2], counts[fail][Read2])
-	fmt.Printf("%d + %d properly paired\n", counts[pass][ProperPair], counts[fail][ProperPair])
-	fmt.Printf("%d + %d singletons\n", counts[pass][MateUnmapped], counts[fail][MateUnmapped])
-	fmt.Printf("%d + %d with mate mapped to a different chr\n", mates[pass].low, mates[fail].low)
-	fmt.Printf("%d + %d with mate mapped to a different chr (mapQ >= 5)\n", mates[pass].high, mates[fail].high)
+	fmt.Printf("%d + %d properly paired (%s : %s)\n", good[pass], good[fail], percent(good[pass], counts[pass][Paired]), percent(good[fail], counts[fail][Paired]))
+	fmt.Printf("%d + %d with itself and mate mapped\n", paired[pass], paired[fail])
+	fmt.Printf("%d + %d singletons (%s : %s)\n", singletons[pass], singletons[fail], percent(singletons[pass], counts[pass][Paired]), percent(singletons[fail], counts[fail][Paired]))
+	fmt.Printf("%d + %d with mate mapped to a different chr\n", mates[pass].allMapQ, mates[fail].allMapQ)
+	fmt.Printf("%d + %d with mate mapped to a different chr (mapQ>=5)\n", mates[pass].highMapQ, mates[fail].highMapQ)
+}
+
+func percent(n, total uint64) string {
+	if total == 0 {
+		return "N/A"
+	}
+	return fmt.Sprintf("%.2f%%", 100*float64(n)/float64(total))
 }
 
 // The flag indexes for SAM flags. Reflects sam.Flag order.
 const (
-	Paired        = iota // The read is paired in sequencing, no matter whether it is mapped in a pair.
-	ProperPair           // The read is mapped in a proper pair.
-	Unmapped             // The read itself is unmapped; conflictive with ProperPair.
-	MateUnmapped         // The mate is unmapped.
-	Reverse              // The read is mapped to the reverse strand.
-	MateReverse          // The mate is mapped to the reverse strand.
-	Read1                // This is read1.
-	Read2                // This is read2.
-	Secondary            // Not primary alignment.
-	QCFail               // QC failure.
-	Duplicate            // Optical or PCR duplicate.
-	Supplementary        // Supplementary alignment, indicates alignment is part of a chimeric alignment.
+	Paired        uint = iota // The read is paired in sequencing, no matter whether it is mapped in a pair.
+	ProperPair                // The read is mapped in a proper pair.
+	Unmapped                  // The read itself is unmapped; conflictive with ProperPair.
+	MateUnmapped              // The mate is unmapped.
+	Reverse                   // The read is mapped to the reverse strand.
+	MateReverse               // The mate is mapped to the reverse strand.
+	Read1                     // This is read1.
+	Read2                     // This is read2.
+	Secondary                 // Not primary alignment.
+	QCFail                    // QC failure.
+	Duplicate                 // Optical or PCR duplicate.
+	Supplementary             // Supplementary alignment, indicates alignment is part of a chimeric alignment.
 )


### PR DESCRIPTION
@brentp Please take a look.

This is a harsher benchmark and one that is used across implementations. We come out worse, but it is more realistic a test of use (the performance drop is likely due to the fact that GC becomes more of an issue for a long run). The change also makes the Go program a workalike to make comparison more convincing and simplifies some of the logic - we are still doing work that is unnecessary, but fixing that makes it more complicated.