### PR TITLE
sam: optimize ParseAux

### DIFF
--- a/sam/sam_test.go
+++ b/sam/sam_test.go
@@ -842,3 +842,17 @@ func BenchmarkParseCigar(b *testing.B) {
 		}
 	}
 }
+
+func benchmarkAux(b *testing.B, aux []byte) {
+	for i := 0; i < b.N; i++ {
+		_, err := ParseAux(aux)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseAuxInt(b *testing.B)   { benchmarkAux(b, []byte("NM:i:1")) }
+func BenchmarkParseAuxZ(b *testing.B)     { benchmarkAux(b, []byte("SA:Z:ref,29,-,6H5M,17,0;")) }
+func BenchmarkParseAuxFloat(b *testing.B) { benchmarkAux(b, []byte("FL:f:100042.42")) }
+func BenchmarkParseAuxArray(b *testing.B) { benchmarkAux(b, []byte("BB:B:i,629,1095")) }


### PR DESCRIPTION
update #89

change on (newly added) aux parsing benchmark:

```
name        old time/op    new time/op    delta
ParseAux-4     661ns ± 3%     256ns ± 1%  -61.20%  (p=0.000 n=8+10)

name        old alloc/op   new alloc/op   delta
ParseAux-4      376B ± 0%      128B ± 0%  -65.96%  (p=0.000 n=10+10)

name        old allocs/op  new allocs/op  delta
ParseAux-4      12.0 ± 0%       7.0 ± 0%  -41.67%  (p=0.000 n=10+10)
```