### PR TITLE
bgzf: set default OS to unknown

### DIFF
--- a/bgzf/bgzf_test.go
+++ b/bgzf/bgzf_test.go
@@ -202,6 +202,9 @@ func TestRoundTrip(t *testing.T) {
 	if r.Name != "name" {
 		t.Errorf("name is %q, want %q", r.Name, "name")
 	}
+	if r.OS != 0xff {
+		t.Errorf("os is %x, want %x", r.OS, 0xff)
+	}
 	if err := r.Close(); err != nil {
 		t.Errorf("Reader.Close: %v", err)
 	}

--- a/bgzf/writer.go
+++ b/bgzf/writer.go
@@ -63,6 +63,7 @@ func NewWriterLevel(w io.Writer, level, wc int) (*Writer, error) {
 		waiting: make(chan *compressor, wc),
 		queue:   make(chan *compressor, wc),
 	}
+	bg.Header.OS = 0xff // Set default OS to unknown.
 
 	c := make([]compressor, wc)
 	for i := range c {


### PR DESCRIPTION
This is submitted with contrition. I had thought compress/gzip defaulted to the zero byte. This is not true; I was clobbering the 0xff value it has by default (since 2012!).

@brentp Please take a look.