### PR TITLE
bgzf: fix block size handling errors

### DIFF
--- a/bgzf/bgzf.go
+++ b/bgzf/bgzf.go
@@ -45,6 +45,7 @@ func init() {
 
 var (
 	ErrClosed            = errors.New("bgzf: use of closed writer")
+	ErrCorrupt           = errors.New("bgzf: corrupt block")
 	ErrBlockOverflow     = errors.New("bgzf: block overflow")
 	ErrWrongFileType     = errors.New("bgzf: file is a directory")
 	ErrNoEnd             = errors.New("bgzf: cannot determine offset from end")

--- a/bgzf/reader.go
+++ b/bgzf/reader.go
@@ -292,6 +292,9 @@ func (d *decompressor) readMember() error {
 		return ErrNoBlockSize
 	}
 	skipped := int(d.cr.offset() - mark)
+	if d.blockSize < skipped {
+		return ErrCorrupt
+	}
 
 	// Read compressed data into the decompressor buffer until the
 	// underlying flate.Reader is positioned at the end of the gzip

--- a/bgzf/reader.go
+++ b/bgzf/reader.go
@@ -292,14 +292,17 @@ func (d *decompressor) readMember() error {
 		return ErrNoBlockSize
 	}
 	skipped := int(d.cr.offset() - mark)
-	if d.blockSize < skipped {
+	need := d.blockSize - skipped
+	if need == 0 {
+		return io.EOF
+	} else if need < 0 {
 		return ErrCorrupt
 	}
 
 	// Read compressed data into the decompressor buffer until the
 	// underlying flate.Reader is positioned at the end of the gzip
 	// member in which the readMember call was made.
-	return d.buf.readLimited(d.blockSize-skipped, d.cr)
+	return d.buf.readLimited(need, d.cr)
 }
 
 // Offset is a BGZF virtual offset.


### PR DESCRIPTION
Found by go-fuzz, hinted at by #108.

I re-ran the bgzf go-fuzz code at the issue above and can more simply fix the errors by handling the zero and negative needed limited read cases.

I am not entirely sure of the zero-size case. I suspect that the `io.EOF` should be revised to a `nil` error after it has been intercepted after `d.readMember` returns in `decompressor.nextBlockAt`, but I would prefer this failure to the panic that exists, though please have a think about that.

I think the fuzzing has saturated, but I'll leave it running for a while.

@brentp Please take a look.