### PR TITLE
bam: fix various bounds checks

### DIFF
--- a/bam/bam_test.go
+++ b/bam/bam_test.go
@@ -2419,9 +2419,14 @@ var fuzzCrashers = []string{
 		"0000\a000\x00\x0000\x00\x00\x00\x000000" +
 		"00000000000000000\b00" +
 		"0",
-
 	"BAM\x01\x00\x00ewline;�\xbf\xb2\x10e" +
 		"�\x16\x00\x00\x00\x00\x00\xbf89rf",
+
+	// lSeq overflow.
+	"BAM\x01\x00\x00\x00\x00\x00\x00\x00\x000\x00\x00\x000000" +
+		"000000000000\xff\xff\xff\u007f0000" +
+		"00000000000000000000" +
+		"00000000",
 }
 
 func TestFuzzCrashers(t *testing.T) {

--- a/bam/bam_test.go
+++ b/bam/bam_test.go
@@ -2427,6 +2427,12 @@ var fuzzCrashers = []string{
 		"000000000000\xff\xff\xff\u007f0000" +
 		"00000000000000000000" +
 		"00000000",
+
+	// B-type aux data length overflow.
+	"BAM\x01\x00\x00\x00\x00\x00\x00\x00\x000\x00\x00\x000000" +
+		"0000\x01000\x01\x0000\x00\x00\x00\x000000" +
+		"000000000000000BC000" +
+		"00000000",
 }
 
 func TestFuzzCrashers(t *testing.T) {

--- a/bam/reader.go
+++ b/bam/reader.go
@@ -337,14 +337,9 @@ func parseAux(aux []byte) ([]sam.Aux, error) {
 		case j < 0:
 			switch t {
 			case 'Z', 'H':
-				var (
-					j int
-					v byte
-				)
-				for j, v = range aux[i:] {
-					if v == 0 { // C string termination
-						break // Truncate terminal zero.
-					}
+				j := bytes.IndexByte(aux[i:], 0)
+				if j == -1 {
+					return nil, errors.New("bam: invalid zero terminated data: no zero")
 				}
 				aa = append(aa, sam.Aux(aux[i:i+j:i+j]))
 				i += j + 1

--- a/bam/reader.go
+++ b/bam/reader.go
@@ -349,12 +349,11 @@ func parseAux(aux []byte) ([]sam.Aux, error) {
 				aa = append(aa, sam.Aux(aux[i:i+j:i+j]))
 				i += j + 1
 			case 'B':
-				var length int32
-				err := binary.Read(bytes.NewBuffer([]byte(aux[i+4:i+8])), binary.LittleEndian, &length)
-				if err != nil {
-					panic(fmt.Sprintf("bam: binary.Read failed: %v", err))
-				}
+				length := binary.LittleEndian.Uint32(aux[i+4 : i+8])
 				j = int(length)*jumps[aux[i+3]] + int(unsafe.Sizeof(length)) + 4
+				if i+j > len(aux) {
+					return nil, fmt.Errorf("bam: invalid array length for aux data: %d", length)
+				}
 				aa = append(aa, sam.Aux(aux[i:i+j:i+j]))
 				i += j
 			}


### PR DESCRIPTION
This fixes a couple of bounds errors found by go-fuzz, and extrapolates to another. The code is safer from other perspectives and also a little less horrible in its use of unsafe. I suspect there may be performance improvements from some of the changes as well.

@brentp Please take a look.