### PR TITLE
Add GetAllOffsets() to retrieve block offsets from a BAM index

### DIFF
--- a/bam/merger_example_test.go
+++ b/bam/merger_example_test.go
@@ -122,7 +122,7 @@ func writeChunk(dir string, h *sam.Header, recs []*sam.Record) (*bam.Reader, err
 
 	f, err := ioutil.TempFile(dir, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file %q: %v", err)
+		return nil, fmt.Errorf("failed to create temp file in %q: %v", dir, err)
 	}
 
 	bw, err := bam.NewWriter(f, h, 0)


### PR DESCRIPTION
It is possible to use the offsets from the .bai index file to find
block start positions in the corresponding .bam file.  The block start
positions, are useful for dividing a bam file into approximately equal
sized pieces for subsequent processing.

Also fix a compile error in bam/merger_example_test.go.