### PR TITLE
bam: Use libdeflate instead of the standard compress/{gzip,flate}

### DIFF
--- a/bgzf/cache.go
+++ b/bgzf/cache.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
+
+	"github.com/grailbio/base/compress/libdeflate"
 )
 
 // Cache is a Block caching type. Basic cache implementations are provided
@@ -75,7 +77,9 @@ type Block interface {
 	// the file origin offset case and does not
 	// return the new offset.
 	seek(offset int64) error
-	readFrom(io.ReadCloser) error
+
+	// readBuf uncompresses the given input data.
+	readBuf(in []byte, dd libdeflate.Decompressor) error
 
 	// len returns the number of remaining
 	// bytes that can be read from the Block.
@@ -125,44 +129,17 @@ func (b *block) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// readToEOF will exhaust r or fill buf.
-// If r does not EOF upon reading up to len(buf) bytes then readToEOF will return
-// io.ErrShortBuffer and an additional byte will be discarded from the reader.
-func readToEOF(r io.Reader, buf []byte) (n int, err error) {
-	for err == nil && n < len(buf) {
-		var nn int
-		nn, err = r.Read(buf[n:])
-		n += nn
-	}
-	switch {
-	case err == io.EOF:
-		return n, nil
-	case n == MaxBlockSize && err == nil:
-		// This is paranoic, but some readers will return
-		// quickly when passed a zero-length byte slice.
-		var dummy [1]byte
-		_, err = r.Read(dummy[:])
-		if err == nil {
-			return n, io.ErrShortBuffer
-		}
-		if err == io.EOF {
-			err = nil
-		}
-	}
-	return n, err
-}
-
-func (b *block) readFrom(r io.ReadCloser) error {
+func (b *block) readBuf(inData []byte, dd libdeflate.Decompressor) error {
 	o := b.owner
 	b.owner = nil
-	n, err := readToEOF(r, b.data[:])
+	n, err := dd.Decompress(b.data[:], inData)
 	if err != nil {
 		return err
 	}
 	b.buf = bytes.NewReader(b.data[:n])
 	b.owner = o
 	b.magic = b.magic && b.len() == 0
-	return r.Close()
+	return nil
 }
 
 func (b *block) seek(offset int64) error {


### PR DESCRIPTION
It results in 2x to 4x performance improvements.

github.com/biogo/hts/bgzf

Before:
  BenchmarkWrite-56              1        2087464279 ns/op
  BenchmarkRead-56               1        4452965285 ns/op

After:
  BenchmarkWrite-56    	       1	1069021742 ns/op
  BenchmarkRead-56     	       1	1195341566 ns/op

Hardware: 56 * Xeon E5-2690@2.60GHz, 256GiB memory.