### PR TITLE
bam: fix qual encoding length for nil qualities

### DIFF
--- a/bam/writer.go
+++ b/bam/writer.go
@@ -85,7 +85,7 @@ func (bw *Writer) Write(r *sam.Record) error {
 		len(r.Name) + 1 + // Null terminated.
 		len(r.Cigar)<<2 + // CigarOps are 4 bytes.
 		len(r.Seq.Seq) +
-		len(r.Qual) +
+		r.Seq.Length +
 		len(tags)
 
 	bw.buf.Reset()


### PR DESCRIPTION
Fixes defect found in #132 more simply.

Please take a look.

/cc @bsipos