### PR TITLE
bam: prevent -1 becoming positive in conversion to int

### DIFF
--- a/bam/reader.go
+++ b/bam/reader.go
@@ -126,7 +126,7 @@ func (br *Reader) Read() (*sam.Record, error) {
 
 	var rec sam.Record
 	refID := b.readInt32()
-	rec.Pos = int(b.readUint32())
+	rec.Pos = int(b.readInt32())
 	nLen := b.readUint8()
 	rec.MapQ = b.readUint8()
 	b.discard(2)

--- a/bam/reader.go
+++ b/bam/reader.go
@@ -428,17 +428,6 @@ func (b *buffer) readInt32() int32 {
 	return int32(binary.LittleEndian.Uint32(b.bytes(4)))
 }
 
-func (b *buffer) readUint32() uint32 {
-	if b.err != nil {
-		return 0
-	}
-	if b.len() < 4 {
-		b.err = io.ErrUnexpectedEOF
-		return 0
-	}
-	return binary.LittleEndian.Uint32(b.bytes(4))
-}
-
 // newBuffer returns a new buffer reading from the Reader's underlying bgzf.Reader and
 // updates the Reader's lastChunk field.
 func newBuffer(br *Reader) (*buffer, error) {


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies bíogo to _____."
-->
