### PR TITLE
bam: iterate over file when no chunks are given

### DIFF
--- a/bam/bam_test.go
+++ b/bam/bam_test.go
@@ -422,12 +422,14 @@ func (s *S) TestSpecExamplesIterator(c *check.C) {
 	c.Assert(err, check.Equals, nil)
 	it, err := NewIterator(br, nil)
 	c.Assert(err, check.Equals, nil)
-	for i := 0; it.Next(); i++ {
+	i := 0
+	for ; it.Next(); i++ {
 		expect := specExamples.records[i]
 		r := it.Record()
 		c.Check(r.Name, check.Equals, expect.Name)
 		c.Check(r.Pos, check.Equals, expect.Pos)
 	}
+	c.Assert(i, check.Equals, len(specExamples.records))
 	c.Assert(it.Error(), check.Equals, nil)
 }
 

--- a/bam/reader.go
+++ b/bam/reader.go
@@ -256,7 +256,7 @@ type Iterator struct {
 //
 func NewIterator(r *Reader, chunks []bgzf.Chunk) (*Iterator, error) {
 	if len(chunks) == 0 {
-		return &Iterator{r: r, err: io.EOF}, nil
+		return &Iterator{r: r}, nil
 	}
 	err := r.SetChunk(&chunks[0])
 	if err != nil {


### PR DESCRIPTION
Please take a look.

Previous test was skipped. The `n` incrementing now checks that ieration actually occurs.