### PR TITLE
sam: keep otherTags when adding a duplicate reference on BAM read

### DIFF
--- a/sam/header.go
+++ b/sam/header.go
@@ -499,6 +499,9 @@ func (bh *Header) AddReference(r *Reference) error {
 		if r.uri == nil {
 			r.uri = er.uri
 		}
+		if r.otherTags == nil {
+			r.otherTags = er.otherTags
+		}
 		bh.refs[dupID] = r
 		return nil
 	}


### PR DESCRIPTION
This PR fixes an issue where the BAM reader (via `bam.DecodeBinary`) did not preserve additional tags for reference entries in the header. If, for example, a reference had a `DS:foo` tag, it would not be preserved in the final header after decoding.

This occurred because the BAM format lists the references in two places: the "text" portion and a binary-encoded list of references. The reading of the binary-encoded list (in `bam.DecodeBinary`) overrode some parts of the references read via the text portion and did not preserve the `otherTags` field of references that had already been read in the text portion of the header.

The fix is in `sam.Header.AddReference`: when adding a reference that has already been seen, if the reference being added has a nil `otherTags`, use the existing tags. This follows the pattern already used in `AddReference` for the `md5`, `assemID`, etc. fields. 

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies bíogo to _____."
-->
