### PR TITLE
bgzf: Added check to avoid nil pointer dereference panic when seeking 

### DIFF
--- a/bgzf/reader.go
+++ b/bgzf/reader.go
@@ -449,7 +449,7 @@ func (bg *Reader) Seek(off Offset) error {
 		return ErrNotASeeker
 	}
 
-	if off.File != bg.current.Base() || !bg.current.hasData() {
+	if bg.current == nil || off.File != bg.current.Base() || !bg.current.hasData() {
 		ok := bg.cacheSwap(off.File)
 		if !ok {
 			var dec *decompressor


### PR DESCRIPTION
Occasionally in bgzf/reader.go bg.current is set to nil, which can cause a panic when then attempting to Seek(). This adds a check for nil prior to attempting to use bg.current