### PR TITLE
internal/pool: add a buffer pool and use it

### DIFF
--- a/bgzf/bgzf.go
+++ b/bgzf/bgzf.go
@@ -13,6 +13,8 @@ import (
 	"io"
 	"os"
 	"time"
+
+	"github.com/biogo/hts/internal/pool"
 )
 
 const (
@@ -91,7 +93,8 @@ func HasEOF(r io.ReaderAt) (bool, error) {
 		return false, ErrNoEnd
 	}
 
-	b := make([]byte, len(magicBlock))
+	b := pool.GetBuffer(len(magicBlock))
+	defer pool.PutBuffer(b)
 	_, err := r.ReadAt(b, size-int64(len(magicBlock)))
 	if err != nil {
 		return false, err

--- a/cram/cram.go
+++ b/cram/cram.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/biogo/hts/cram/encoding/itf8"
 	"github.com/biogo/hts/cram/encoding/ltf8"
+	"github.com/biogo/hts/internal/pool"
 	"github.com/biogo/hts/sam"
 )
 
@@ -81,7 +82,8 @@ func HasEOF(r io.ReaderAt) (bool, error) {
 		return false, ErrNoEnd
 	}
 
-	b := make([]byte, len(cramEOFmarker))
+	b := pool.GetBuffer(len(cramEOFmarker))
+	defer pool.PutBuffer(b)
 	_, err := r.ReadAt(b, size-int64(len(cramEOFmarker)))
 	if err != nil {
 		return false, err

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1,0 +1,50 @@
+// Copyright ©2021 The bíogo Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pool
+
+import (
+	"math/bits"
+	"sync"
+)
+
+// pool contains size stratified []byte pools. Each pool element i
+// returns sized matrices with a slice capped at 1<<i.
+var pool [63]sync.Pool
+
+func init() {
+	for i := range pool {
+		l := 1 << uint(i)
+		// Real matrix pools.
+		pool[i].New = func() interface{} {
+			return make([]byte, l)
+		}
+	}
+}
+
+// GetBuffer returns a []byte of with len size and a cap that is
+// less than 2*size.
+func GetBuffer(size int) []byte {
+	if size == 0 {
+		return nil
+	}
+	b := pool[poolFor(uint(size))].Get().([]byte)
+	return b[:size]
+}
+
+// PutBuffer replaces a used []byte into the appropriate size
+// buffer pool.
+func PutBuffer(buf []byte) {
+	if buf == nil {
+		return
+	}
+	pool[poolFor(uint(cap(buf)))].Put(buf[:0])
+}
+
+// poolFor returns the ceiling of base 2 log of size. It provides an index
+// into a pool array to a sync.Pool that will return values able to hold
+// size elements.
+func poolFor(size uint) int {
+	return bits.Len(size - 1)
+}

--- a/sam/parse_header.go
+++ b/sam/parse_header.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/biogo/hts/internal/pool"
 )
 
 var (
@@ -52,7 +54,8 @@ func (bh *Header) DecodeBinary(r io.Reader) error {
 	if lText < 0 {
 		return errors.New("sam: invalid text length")
 	}
-	text := make([]byte, lText)
+	text := pool.GetBuffer(int(lText))
+	defer pool.PutBuffer(text)
 	n, err := r.Read(text)
 	if err != nil {
 		return err
@@ -103,7 +106,8 @@ func readRefRecords(r io.Reader, n int32) ([]*Reference, error) {
 		if lName < 1 {
 			return nil, errors.New("sam: invalid name length")
 		}
-		name := make([]byte, lName)
+		name := pool.GetBuffer(int(lName))
+		defer pool.PutBuffer(name)
 		n, err := r.Read(name)
 		if err != nil {
 			return nil, err

--- a/sam/record.go
+++ b/sam/record.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 
 	"github.com/biogo/hts/internal"
+	"github.com/biogo/hts/internal/pool"
 )
 
 // Record represents a SAM/BAM record.
@@ -388,7 +389,8 @@ func formatFlags(f Flags, format int) interface{} {
 
 		const flags = "pPuUrR12sfdS"
 
-		b := make([]byte, 0, len(flags))
+		b := pool.GetBuffer(len(flags))[:0]
+		defer pool.PutBuffer(b)
 		for i, c := range flags {
 			if f&(1<<uint(i)) != 0 {
 				b = append(b, byte(c))

--- a/tabix/tabix.go
+++ b/tabix/tabix.go
@@ -15,6 +15,7 @@ import (
 	"github.com/biogo/hts/bgzf"
 	"github.com/biogo/hts/bgzf/index"
 	"github.com/biogo/hts/internal"
+	"github.com/biogo/hts/internal/pool"
 )
 
 // Index is a tabix index.
@@ -206,7 +207,8 @@ func readTabixHeader(r io.Reader, idx *Index) error {
 	if err != nil {
 		return fmt.Errorf("tabix: failed to read name lengths: %v", err)
 	}
-	nameBytes := make([]byte, n)
+	nameBytes := pool.GetBuffer(int(n))
+	defer pool.PutBuffer(nameBytes)
 	_, err = io.ReadFull(r, nameBytes)
 	if err != nil {
 		return fmt.Errorf("tabix: failed to read names: %v", err)


### PR DESCRIPTION
DO NOT MERGE

This exists just to demonstrate that a pool is not effective in case it comes up in the future.

```
name              old time/op    new time/op    delta
Read-8               4.24s ± 3%     4.67s ± 1%  +10.26%  (p=0.000 n=9+10)
ReadCoreAndSeq-8     3.37s ± 6%     3.58s ± 0%   +6.26%  (p=0.000 n=10+9)
ReadCoreOnly-8       3.32s ± 6%     3.52s ± 2%   +6.05%  (p=0.000 n=10+10)
ReadFile-8           4.19s ± 1%     4.66s ± 1%  +11.14%  (p=0.000 n=9+9)

name              old alloc/op   new alloc/op   delta
Read-8              2.35GB ± 0%    2.13GB ± 0%   -9.42%  (p=0.000 n=10+10)
ReadCoreAndSeq-8    1.05GB ± 0%    0.74GB ± 0%  -30.14%  (p=0.000 n=10+10)
ReadCoreOnly-8       991MB ± 0%     673MB ± 0%  -32.09%  (p=0.000 n=9+10)
ReadFile-8          2.35GB ± 0%    2.13GB ± 0%   -9.42%  (p=0.000 n=10+10)

name              old allocs/op  new allocs/op  delta
Read-8               18.1M ± 0%     24.1M ± 0%  +32.95%  (p=0.000 n=10+10)
ReadCoreAndSeq-8     12.3M ± 0%     16.3M ± 0%  +32.59%  (p=0.000 n=10+10)
ReadCoreOnly-8       10.3M ± 0%     14.3M ± 0%  +38.93%  (p=0.000 n=10+10)
ReadFile-8           18.1M ± 0%     24.1M ± 0%  +32.95%  (p=0.000 n=10+10)
```

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies bíogo to _____."
-->
