### PR TITLE
bam: use heuristics to reduce reallocation

### DIFF
--- a/bam/reader.go
+++ b/bam/reader.go
@@ -336,7 +336,11 @@ func parseAux(buf []byte) ([]sam.Aux, error) {
 	// See https://github.com/golang/go/issues/45038 for bytes.Clone.
 	aux := append(buf[:0:0], buf...)
 
-	aa := make([]sam.Aux, 0, 4)
+	// Heuristically pre-allocate enough slots for the byte data.
+	// Value chosen by experimentation and will not fit all inputs,
+	// with the cost being over-allocation.
+	aa := make([]sam.Aux, 0, len(aux)/4)
+
 	for i := 0; i+2 < len(aux); {
 		t := aux[i+2]
 		switch j := jumps[t]; {


### PR DESCRIPTION
The only remaining area of optimisation is in decoding headers for the allocation of `text`, but there only pooled buffers are possible. I tried this using the system in #156 and it had no impact either way.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies bíogo to _____."
-->
