### PR TITLE
bgzf: fix test with go1.19

### DIFF
--- a/bgzf/bgzf_test.go
+++ b/bgzf/bgzf_test.go
@@ -1133,7 +1133,7 @@ func TestFuzzCrashers(t *testing.T) {
 			switch err {
 			case nil:
 				// Pass through.
-			case io.EOF, ErrCorrupt:
+			case io.EOF, io.ErrUnexpectedEOF, ErrCorrupt:
 				return
 			default:
 				t.Fatalf("unexpected error creating reader: %v", err)


### PR DESCRIPTION
Due to https://github.com/golang/go/issues/51417
Go1.19 also returns io.ErrUnexpectedEOF for invalid gzip input.